### PR TITLE
Bugfixes

### DIFF
--- a/Assets/Player/Scripts/PlayerMovement.cs
+++ b/Assets/Player/Scripts/PlayerMovement.cs
@@ -69,7 +69,7 @@ public class PlayerMovement : MonoBehaviour {
     public ArrayList minimapExploredList;
     static public Dictionary<string, string[]> minimapExplored;
     public PauseMenu pm;
-    public bool test = false;
+    public bool showPauseMenu = false;
 
     void Start() {
         rb = GetComponent<Rigidbody2D>();
@@ -99,7 +99,7 @@ public class PlayerMovement : MonoBehaviour {
                 SaveLoad.loadData("TempSaveData");
                 // Ensure we delete the TempSaveData.bin file after loading
                 File.Delete(Application.persistentDataPath + "/TempSaveData.bin");
-                test = true;
+                showPauseMenu = true;
             }
         } catch (Exception e) {
             // Ignore the exception
@@ -108,10 +108,10 @@ public class PlayerMovement : MonoBehaviour {
 
     void Update() {
 
-        if (test) 
+        if (showPauseMenu) 
         {
             pm.setExternalPause(true);
-            test = false;
+            showPauseMenu = false;
         }
 
         // Minimap fog of war checks \\

--- a/Assets/Player/Scripts/PlayerMovement.cs
+++ b/Assets/Player/Scripts/PlayerMovement.cs
@@ -107,7 +107,8 @@ public class PlayerMovement : MonoBehaviour {
                 newColour = tempRoom.GetComponentsInChildren<SpriteRenderer>()[1].color;
                 newColour.a = 255;
                 tempRoom.GetComponentsInChildren<SpriteRenderer>()[1].color = newColour;
-                minimapExploredList.Add(tempRoom.name);
+                if (!minimapExploredList.Contains(tempRoom.name))
+                    minimapExploredList.Add(tempRoom.name);
             }
         }
 
@@ -267,8 +268,15 @@ public class PlayerMovement : MonoBehaviour {
                 {
                     for (int k = 0; k <SaveLoad.minimapExplored.ElementAt(i).Value.Count(); k++) {
                         GameObject tempRoom = (GameObject) GameObject.Find(SaveLoad.minimapExplored.ElementAt(i).Value[k]);
-                        if (tempRoom)
-                            tempRoom.active = false;
+                        if (tempRoom) {
+                            Color newColour = tempRoom.GetComponent<SpriteRenderer>().color;
+                            newColour.a = 255;
+                            tempRoom.GetComponent<SpriteRenderer>().color = newColour;
+
+                            newColour = tempRoom.GetComponentsInChildren<SpriteRenderer>()[1].color;
+                            newColour.a = 255;
+                            tempRoom.GetComponentsInChildren<SpriteRenderer>()[1].color = newColour;
+                        }
                     }
                 }
             }

--- a/Assets/Player/Scripts/PlayerMovement.cs
+++ b/Assets/Player/Scripts/PlayerMovement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -67,6 +68,8 @@ public class PlayerMovement : MonoBehaviour {
     public ArrayList rooms;
     public ArrayList minimapExploredList;
     static public Dictionary<string, string[]> minimapExplored;
+    public PauseMenu pm;
+    public bool test = false;
 
     void Start() {
         rb = GetComponent<Rigidbody2D>();
@@ -85,9 +88,31 @@ public class PlayerMovement : MonoBehaviour {
             rooms.Add(temp);
             i++;
         }
+        pm = GameObject.FindObjectOfType(typeof(PauseMenu)) as PauseMenu;
+        bool check = false;
+        if (pm.getPaused()) {
+            check = true;
+        }
+        try {
+            if (System.IO.File.Exists(Application.persistentDataPath + "/TempSaveData.bin") && check) 
+            {
+                SaveLoad.loadData("TempSaveData");
+                // Ensure we delete the TempSaveData.bin file after loading
+                File.Delete(Application.persistentDataPath + "/TempSaveData.bin");
+                test = true;
+            }
+        } catch (Exception e) {
+            // Ignore the exception
+        }
     }
 
     void Update() {
+
+        if (test) 
+        {
+            pm.setExternalPause(true);
+            test = false;
+        }
 
         // Minimap fog of war checks \\
         for (int i = 0; i < rooms.Count; i++) {
@@ -242,8 +267,6 @@ public class PlayerMovement : MonoBehaviour {
         verticalV = Mathf.Clamp(verticalV, -maxFallSpeed, float.MaxValue); // Clamp the vertical velocity, otherwise it will increase forever, and makes the player fall way too fast
         rb.velocity = new Vector3(horizontalV, verticalV, 0);
         anim.UpdateVelocity(inputController.getHorizontalAxis(), verticalV);
-
-
         // Save Loading \\
         if (SaveLoad.loaded)
         {
@@ -283,6 +306,8 @@ public class PlayerMovement : MonoBehaviour {
             minimapExplored = SaveLoad.minimapExplored;
             SaveLoad.clear();
             SaveLoad.loaded = false;
+            pm.setPaused(false);
+            pm.ResumeGame();
             
         }
         // Autosave checks

--- a/Assets/Scenes/PauseMenu.prefab
+++ b/Assets/Scenes/PauseMenu.prefab
@@ -251,6 +251,49 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2589287407733660023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1671225442427282961}
+  - component: {fileID: 4559996981491060633}
+  m_Layer: 0
+  m_Name: SettingsObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1671225442427282961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2589287407733660023}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 224.05457, y: 8.056824, z: -31553.87}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7927848840138067072}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4559996981491060633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2589287407733660023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a7ec2380d9271946b0edac9a09c39ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2767249741588351684
 GameObject:
   m_ObjectHideFlags: 0
@@ -877,7 +920,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 2
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -1010,7 +1053,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 2
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -1041,7 +1084,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 4559996981491060633}
         m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
         m_MethodName: LoadScene
         m_Mode: 5
@@ -1090,6 +1133,7 @@ RectTransform:
   - {fileID: 7927848840900174294}
   - {fileID: 5911678662461147174}
   - {fileID: 8866902688677087674}
+  - {fileID: 1671225442427282961}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1226,7 +1270,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 2
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
@@ -1347,8 +1391,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
+    m_Mode: 2
+    m_WrapAround: 1
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1468,8 +1512,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
+    m_Mode: 2
+    m_WrapAround: 1
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}

--- a/Assets/Scripts/ChangeScene.cs
+++ b/Assets/Scripts/ChangeScene.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+
 
 
 //This script is used to load in a new scene 
@@ -11,6 +14,26 @@ public class ChangeScene : MonoBehaviour
     //using SceneManager
     public void LoadScene(string sceneName)
     {
+        if (string.Compare(SceneManager.GetActiveScene().name, "StartMenu") == 0 && string.Compare(sceneName, "SettingsMenu") == 0) 
+        {
+            File.Create(Application.persistentDataPath + "/startMenuTempFile").Dispose();
+        }
         SceneManager.LoadScene(sceneName);
+    }
+
+    public void LoadSceneAndSave(string sceneName)
+    {
+        try {
+            if (System.IO.File.Exists(Application.persistentDataPath + "/startMenuTempFile")) 
+            {
+                File.Delete(Application.persistentDataPath + "/startMenuTempFile");
+                SceneManager.LoadScene("StartMenu");
+                return;
+            }
+            // Save temp data for loading after closing settings menu
+            new PlayerData().popluateData("TempSaveData");
+            SceneManager.LoadScene(sceneName);
+        } catch (Exception e) {
+        }
     }
 }

--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -6,21 +6,23 @@ public class PauseMenu : MonoBehaviour
 {
     //Class Variables
     [SerializeField] private GameObject pauseMenuUI;
-    [SerializeField] private bool gameIsPaused;
+    [SerializeField] private static bool gameIsPaused;
     [SerializeField] private AudioListener audioListener;
+    public bool externalPause = false;
 
     // Update is called once per frame
    private void Update(){
-        if (Input.GetKeyDown(KeyCode.Escape) || Input.GetKeyDown(KeyCode.JoystickButton7)) { // Might be different for other controllers, on my switch pro controller this is the '+' key, 'Home' key doesn't get detected so this is the second best option
+        if (Input.GetKeyDown(KeyCode.Escape) || Input.GetKeyDown(KeyCode.JoystickButton7) || externalPause) { // Might be different for other controllers, on my switch pro controller this is the '+' key, 'Home' key doesn't get detected so this is the second best option
             gameIsPaused = !gameIsPaused;
-
-            if (gameIsPaused) //loop to compare the bool game is paused
+            if (gameIsPaused || externalPause) //loop to compare the bool game is paused
             {
                 GamePaused(); 
             }
             else{
                 ResumeGame();
             }
+            if (externalPause)
+                externalPause = false;
         }
     }
 
@@ -41,7 +43,13 @@ public class PauseMenu : MonoBehaviour
 
     //setter
     public void setPaused(bool p) {
-        this.gameIsPaused = p;
+        gameIsPaused = p;
+    }
+    public bool getPaused() {
+        return gameIsPaused;
     }
 
+    public void setExternalPause(bool b) {
+        this.externalPause = b;
+    }
 }

--- a/Assets/Scripts/Save-Load/SaveLoad.cs
+++ b/Assets/Scripts/Save-Load/SaveLoad.cs
@@ -86,11 +86,11 @@ public static class SaveLoad
     /*
      * Load data from a JSON file on disk and populate ourselves with said data
      */
-    public static void loadData() 
+    public static void loadData(String filename = "SaveData") 
     {
         clear();
 
-        SaveData save = JsonUtility.FromJson<SaveData>(File.ReadAllText(Application.persistentDataPath + "/SaveData.bin"));
+        SaveData save = JsonUtility.FromJson<SaveData>(File.ReadAllText(Application.persistentDataPath + "/" + filename + ".bin"));
 
         activeSceneName = save.activeSceneName;
         position = new float[2];

--- a/Assets/UI/Scripts/UI_Inventory.cs
+++ b/Assets/UI/Scripts/UI_Inventory.cs
@@ -32,6 +32,13 @@ public class UI_Inventory : MonoBehaviour
         int y = 0;
         float powerupSlotCellSize = 5f;
 
+        if (PowerupSlotContainer == null || PowerupSlotTemplate == null || PowerupSlotTemplateText == null) 
+        {
+            PowerupSlotContainer = transform.Find("PowerupSlotContainer");
+            PowerupSlotTemplate = PowerupSlotContainer.Find("PowerupSlotTemplate");
+            PowerupSlotTemplateText = PowerupSlotTemplate.Find("Text");
+        }
+
         // Creates an instance of the template inventory component for each 
         foreach (string powerupName in inventory.GetPowerupList())
         {

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -21,16 +21,16 @@ EditorUserSettings:
       value: 22424703114646680e0b0227036c78111b12373c293a0b35233c5326ece92021
       flags: 0
     RecentlyUsedScenePath-5:
-      value: 22424703114646680e0b0227036c6c0417050c072926337e38271427fb
-      flags: 0
-    RecentlyUsedScenePath-6:
       value: 22424703114646680e0b0227036c731500121478623d28393930
       flags: 0
-    RecentlyUsedScenePath-7:
+    RecentlyUsedScenePath-6:
       value: 22424703114646680e0b0227036c6f1103041d072926337e38271427fb
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-7:
       value: 22424703114646680e0b0227036c6c15020311242b3b0b35233c5326ece92021
+      flags: 0
+    RecentlyUsedScenePath-8:
+      value: 22424703114646680e0b0227036c6c0417050c072926337e38271427fb
       flags: 0
     RecentlyUsedScenePath-9:
       value: 22424703114646680e0b0227036c73150012147b623d28393930

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -6,31 +6,31 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c6f1c17031e253e252f3e2a1b1835e7f23136e1e278fce9332b25
-      flags: 0
-    RecentlyUsedScenePath-1:
       value: 22424703114646680e0b0227036c7c1f18030a25201b232439201334f1c33b36f6f539e5eb3f2d722c0ce6281d
       flags: 0
-    RecentlyUsedScenePath-2:
+    RecentlyUsedScenePath-1:
       value: 22424703114646680e0b0227036c7d021f10103e222d35231e281023eee5073be7e933a7f234362820
       flags: 0
-    RecentlyUsedScenePath-3:
-      value: 22424703114646680e0b0227036c6c15020311242b3b0b35233c5326ece92021
-      flags: 0
-    RecentlyUsedScenePath-4:
+    RecentlyUsedScenePath-2:
       value: 22424703114646680e0b0227036c7c1f18030a25201b232439201334f1ae2136ebf32f
       flags: 0
-    RecentlyUsedScenePath-5:
+    RecentlyUsedScenePath-3:
       value: 22424703114646680e0b0227036c78111b122b2f383c2f3e2a3a5326ece92021
       flags: 0
-    RecentlyUsedScenePath-6:
+    RecentlyUsedScenePath-4:
       value: 22424703114646680e0b0227036c78111b12373c293a0b35233c5326ece92021
       flags: 0
-    RecentlyUsedScenePath-7:
+    RecentlyUsedScenePath-5:
       value: 22424703114646680e0b0227036c6c0417050c072926337e38271427fb
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-6:
       value: 22424703114646680e0b0227036c731500121478623d28393930
+      flags: 0
+    RecentlyUsedScenePath-7:
+      value: 22424703114646680e0b0227036c6f1103041d072926337e38271427fb
+      flags: 0
+    RecentlyUsedScenePath-8:
+      value: 22424703114646680e0b0227036c6c15020311242b3b0b35233c5326ece92021
       flags: 0
     RecentlyUsedScenePath-9:
       value: 22424703114646680e0b0227036c73150012147b623d28393930


### PR DESCRIPTION
(Copy pasting this from discord because I'm lazy :) )

Alright, have fixed these bugs in my bugfixes branch. The settings page now works as expected, doesnt just load level1 whenever you click back. If you're on the startMenu it'll load that, if you're in a level it'll load that level and properly load back in all the relevant data like player position data. 

Fog of war stuff is now saved properly with @Matt's changes, gets saved and loaded as expected.

You can now also get powerups without having to open the inventory first.